### PR TITLE
jdtlsにおいて環境構築を行う処理を実装

### DIFF
--- a/jdtls
+++ b/jdtls
@@ -1,15 +1,15 @@
 #!/usr/bin/env sh
 
-server="${HOME}/lsp"
+server="${HOME}/lsp/eclipse.jdt.ls"
 jdtls_version="0.52.0"
 filename="jdt-language-server-${jdtls_version}-202003042214.tar.gz"
 
-if [ ! -e $server/eclipse.jdt.ls/ ]; then
-    mkdir eclipse.jdt.ls
+if [ ! -e $server ]; then
+    mkdir -p $server/
     if [ ! -e $filename ]; then
         curl -L https://download.eclipse.org/jdtls/milestones/$jdtls_version/$filename -O
     fi
-    tar -xzf $filename -C ./eclipse.jdt.ls
+    tar -xzf $filename -C $server
     rm $filename
 fi
 
@@ -22,7 +22,7 @@ java \
     -Dlog.level=ALL\
     -noverify \
     -Xms1G \
-    -jar $server/eclipse.jdt.ls/plugins/org.eclipse.equinox.launcher_1.5.700.v20200207-2156.jar \
-    -configuration $server/eclipse.jdt.ls/config_linux/ \
+    -jar $server/plugins/org.eclipse.equinox.launcher_1.5.700.v20200207-2156.jar \
+    -configuration $server/config_linux/ \
     -data . \
     "$@"


### PR DESCRIPTION
javaのlspの環境構築が行われていない環境の場合、lspをダウンロードして適切なディレクトリに配置するように修正